### PR TITLE
fix: Use collection threshold on color scheme names

### DIFF
--- a/src/github.py
+++ b/src/github.py
@@ -25,8 +25,6 @@ GITHUB_BASIC_AUTH = (
     else None
 )
 
-GITHUB_FILE_TREE_REQUEST_LIMIT = 30
-
 GITHUB_API_HARD_LIMIT = 1000
 REPOSITORY_LIMIT = os.getenv("REPOSITORY_LIMIT")
 REPOSITORY_LIMIT = int(REPOSITORY_LIMIT) if REPOSITORY_LIMIT is not None else None
@@ -36,7 +34,6 @@ REPOSITORY_LIMIT = min(GITHUB_API_HARD_LIMIT, REPOSITORY_LIMIT)
 this = sys.modules[__name__]
 this.remaining_github_api_calls = None
 this.github_api_rate_limit_reset = None
-this.file_tree_requests_left = GITHUB_FILE_TREE_REQUEST_LIMIT
 
 
 def convert_github_string_datetime(d):
@@ -119,11 +116,11 @@ def list_repositories_of_page(query, page=1):
 # If more than 100 repositories, it will search all pages one by one.
 def search_repositories():
     queries = [
+        "vim theme",
         "vim color scheme",
         "vim colorscheme",
         "vim colour scheme",
         "vim colourscheme",
-        "vim theme",
     ]
 
     repositories = []
@@ -220,11 +217,7 @@ def get_tree_path(tree_object):
 
 
 def get_files_of_tree(owner_name, name, tree_sha, tree_path):
-    if this.file_tree_requests_left <= 0:
-        return []
-
     tree_objects = list_objects_of_tree(owner_name, name, tree_sha)
-    this.file_tree_requests_left -= 1
 
     files = [obj for obj in tree_objects if obj["type"] == "blob"]
     trees = [obj for obj in tree_objects if obj["type"] == "tree"]
@@ -245,8 +238,6 @@ def get_repository_files(repository):
     name = repository["name"]
 
     printer.info(f"Getting files for {owner_name}/{name}")
-
-    this.file_tree_requests_left = GITHUB_FILE_TREE_REQUEST_LIMIT
 
     return get_files_of_tree(
         owner_name, name, repository["default_branch"], repository["default_branch"]

--- a/src/github.py
+++ b/src/github.py
@@ -90,6 +90,8 @@ def github_core_get(url, params=None, log=None):
 
     data = request.get(url=url, params=params, auth=GITHUB_BASIC_AUTH)
 
+    this.remaining_github_api_calls -= 1
+
     return data
 
 

--- a/src/github.py
+++ b/src/github.py
@@ -25,15 +25,18 @@ GITHUB_BASIC_AUTH = (
     else None
 )
 
+GITHUB_FILE_TREE_REQUEST_LIMIT = 30
+
 GITHUB_API_HARD_LIMIT = 1000
 REPOSITORY_LIMIT = os.getenv("REPOSITORY_LIMIT")
 REPOSITORY_LIMIT = int(REPOSITORY_LIMIT) if REPOSITORY_LIMIT is not None else None
 REPOSITORY_LIMIT = min(GITHUB_API_HARD_LIMIT, REPOSITORY_LIMIT)
 
+
 this = sys.modules[__name__]
 this.remaining_github_api_calls = None
 this.github_api_rate_limit_reset = None
-this.file_tree_requests_left = 30
+this.file_tree_requests_left = GITHUB_FILE_TREE_REQUEST_LIMIT
 
 
 def convert_github_string_datetime(d):
@@ -243,7 +246,7 @@ def get_repository_files(repository):
 
     printer.info(f"Getting files for {owner_name}/{name}")
 
-    this.file_tree_requests_left = 20
+    this.file_tree_requests_left = GITHUB_FILE_TREE_REQUEST_LIMIT
 
     return get_files_of_tree(
         owner_name, name, repository["default_branch"], repository["default_branch"]

--- a/src/update_runner.py
+++ b/src/update_runner.py
@@ -215,7 +215,11 @@ def get_repository_vim_color_scheme_names(owner_name, name, files):
     vim_color_scheme_names = []
     for vim_file in vim_files:
         vim_color_scheme_name = get_vim_color_scheme_name(owner_name, name, vim_file)
-        if vim_color_scheme_name is not None and vim_color_scheme_name != "":
+        if (
+            vim_color_scheme_name is not None
+            and vim_color_scheme_name != ""
+            and vim_color_scheme_name not in vim_color_scheme_names
+        ):
             vim_color_scheme_names.append(vim_color_scheme_name)
             if len(vim_color_scheme_names) > VIM_COLLECTION_THRESHOLD:
                 break

--- a/src/update_runner.py
+++ b/src/update_runner.py
@@ -17,7 +17,7 @@ BUILD_WEBHOOK = os.getenv("BUILD_WEBHOOK")
 IMAGE_PATH_REGEX = r"^.*\.(png|jpe?g|webp)$"
 POTENTIAL_VIM_COLOR_SCHEME_PATH_REGEX = r"^.*\.(vim|erb)$"
 
-VIM_COLLECTION_THRESHOLD = 30
+VIM_COLLECTION_THRESHOLD = 15
 
 DAYS_IN_MONTH = 30
 
@@ -173,30 +173,6 @@ def get_image_urls_from_readme(owner_name, name, old_image_urls, max_image_count
     return image_urls
 
 
-def get_repository_vim_color_scheme_names(owner_name, name, files):
-    vim_files = list(
-        filter(
-            lambda file: re.match(POTENTIAL_VIM_COLOR_SCHEME_PATH_REGEX, file["path"]),
-            files,
-        )
-    )
-
-    if len(vim_files) < VIM_COLLECTION_THRESHOLD:
-        vim_color_scheme_names = list(
-            functools.reduce(
-                lambda acc, file_data: add_vim_color_scheme_name(
-                    owner_name, name, acc, file_data
-                ),
-                vim_files,
-                [],
-            )
-        )
-        return vim_color_scheme_names
-
-    printer.info("Repository contains too many vim files; probably a collection")
-    return []
-
-
 def update_stargazers_count_history(repository):
     history = (
         repository["stargazers_count_history"]
@@ -228,18 +204,35 @@ def update_stargazers_count_history(repository):
     return history
 
 
-def add_vim_color_scheme_name(owner_name, name, vim_color_scheme_names, file_data):
-    value = get_vim_color_scheme_name(owner_name, name, file_data)
-    if value is not None and value != "":
-        return vim_color_scheme_names + [value]
-    return vim_color_scheme_names
+def get_repository_vim_color_scheme_names(owner_name, name, files):
+    vim_files = list(
+        filter(
+            lambda file: re.match(POTENTIAL_VIM_COLOR_SCHEME_PATH_REGEX, file["path"]),
+            files,
+        )
+    )
+
+    vim_color_scheme_names = []
+    for vim_file in vim_files:
+        vim_color_scheme_name = get_vim_color_scheme_name(owner_name, name, vim_file)
+        if vim_color_scheme_name is not None and vim_color_scheme_name != "":
+            vim_color_scheme_names.append(vim_color_scheme_name)
+            if len(vim_color_scheme_names) > VIM_COLLECTION_THRESHOLD:
+                break
+
+    if len(vim_color_scheme_names) <= VIM_COLLECTION_THRESHOLD:
+        return vim_color_scheme_names
+
+    printer.info(
+        "Repository contains too many vim color schemes; probably a collection"
+    )
+    return []
 
 
-def get_vim_color_scheme_name(owner_name, name, file_data):
+def get_vim_color_scheme_name(owner_name, name, file):
     vim_color_scheme_name = None
     response = request.get(
-        utils.build_raw_blog_github_url(owner_name, name, file_data["path"]),
-        is_json=False,
+        utils.build_raw_blog_github_url(owner_name, name, file["path"]), is_json=False,
     )
     file_content = response.text if response is not None else ""
 


### PR DESCRIPTION
Closes #15 

* Instead of using vim file count, use unique color scheme name count.
* Many color schemes have separate files for different languages, and
made them invalid.